### PR TITLE
add missing Content-Type header

### DIFF
--- a/src/main/java/dev/jensderuiter/minecraft_imagery/storage/S3StorageProvider.java
+++ b/src/main/java/dev/jensderuiter/minecraft_imagery/storage/S3StorageProvider.java
@@ -105,6 +105,7 @@ public class S3StorageProvider implements StorageProvider {
 
             s3
                 .path(this.bucket, fileName)
+                .header("Content-Type", String.format("image/%s", getExtension()))
                 .method(HttpMethod.PUT)
                 .requestBody(bytes)
                 .execute();


### PR DESCRIPTION
Adds missing Content-Type header, without it, Supabase S3 bucket receives wrong file type.